### PR TITLE
feat(primus): remove env

### DIFF
--- a/.github/workflows/go-fmt.yaml
+++ b/.github/workflows/go-fmt.yaml
@@ -19,7 +19,6 @@ env:
 jobs:
   go:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_type == 'tag' && 'production' || github.ref_name == 'main' && 'staging' || 'review' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -19,7 +19,6 @@ env:
 jobs:
   go:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_type == 'tag' && 'production' || github.ref_name == 'main' && 'staging' || 'review' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -27,7 +27,6 @@ env:
 jobs:
   go:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_type == 'tag' && 'production' || github.ref_name == 'main' && 'staging' || 'review' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/sql-lint.yaml
+++ b/.github/workflows/sql-lint.yaml
@@ -19,7 +19,6 @@ env:
 jobs:
   sql:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_type == 'tag' && 'production' || github.ref_name == 'main' && 'staging' || 'review' }}
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/.github/workflows/sql-test.yaml
+++ b/.github/workflows/sql-test.yaml
@@ -27,7 +27,6 @@ env:
 jobs:
   sql:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref_type == 'tag' && 'production' || github.ref_name == 'main' && 'staging' || 'review' }}
     permissions:
       contents: 'read'
       id-token: 'write'


### PR DESCRIPTION
#### Fixes

- Removed environment assignments in workflow configurations for `go-fmt`, `go-lint`, `go-test`, `sql-lint`, and `sql-test` by removing conditional logic.