### PR TITLE
feat(github): point to ref/repo from PR HEAD, add/remove labels

### DIFF
--- a/.github/workflows/github-add-label.yaml
+++ b/.github/workflows/github-add-label.yaml
@@ -1,0 +1,60 @@
+name: github-add-label
+
+on:
+  workflow_call:
+    inputs:
+      PRIMUS_REF:
+        description: 'The primus ref to checkout.'
+        required: true
+        default: 'main'
+        type: string
+      GITHUB_LABEL_NAME:
+        description: 'The name of the label to add.'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
+jobs:
+  signoz:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: info
+        run: |
+          $MAKE info
+      - name: add-label
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_LABEL_NAME: ${{ inputs.GITHUB_LABEL_NAME }}
+        run: |
+          $MAKE github-add-label \
+            GITHUB_ARGS="-t ${{ steps.token.outputs.token }} \
+              -r ${GH_REPOSITORY} \
+              -i ${GH_ISSUE_NUMBER} \
+              -l '${GH_LABEL_NAME}'"

--- a/.github/workflows/github-add-label.yaml
+++ b/.github/workflows/github-add-label.yaml
@@ -8,6 +8,11 @@ on:
         required: true
         default: 'main'
         type: string
+      GITHUB_ISSUE_NUMBER:
+        description: 'The issue number to add the label to.'
+        required: false
+        type: string
+        default: ${{ github.event.pull_request.number || github.event.issue.number }}
       GITHUB_LABEL_NAME:
         description: 'The name of the label to add.'
         required: true
@@ -50,7 +55,7 @@ jobs:
       - name: add-label
         env:
           GH_REPOSITORY: ${{ github.repository }}
-          GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_ISSUE_NUMBER: ${{ inputs.GITHUB_ISSUE_NUMBER }}
           GH_LABEL_NAME: ${{ inputs.GITHUB_LABEL_NAME }}
         run: |
           $MAKE github-add-label \

--- a/.github/workflows/github-remove-label.yaml
+++ b/.github/workflows/github-remove-label.yaml
@@ -1,0 +1,60 @@
+name: github-remove-label
+
+on:
+  workflow_call:
+    inputs:
+      PRIMUS_REF:
+        description: 'The primus ref to checkout.'
+        required: true
+        default: 'main'
+        type: string
+      GITHUB_LABEL_NAME:
+        description: 'The name of the label to remove.'
+        required: true
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
+jobs:
+  signoz:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: info
+        run: |
+          $MAKE info
+      - name: remove-label
+        env:
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_LABEL_NAME: ${{ inputs.GITHUB_LABEL_NAME }}
+        run: |
+          $MAKE github-remove-label \
+            GITHUB_ARGS="-t ${{ steps.token.outputs.token }} \
+              -r ${GH_REPOSITORY} \
+              -i ${GH_ISSUE_NUMBER} \
+              -l '${GH_LABEL_NAME}'"

--- a/.github/workflows/github-remove-label.yaml
+++ b/.github/workflows/github-remove-label.yaml
@@ -8,6 +8,11 @@ on:
         required: true
         default: 'main'
         type: string
+      GITHUB_ISSUE_NUMBER:
+        description: 'The issue number to remove the label from.'
+        required: false
+        type: string
+        default: ${{ github.event.pull_request.number || github.event.issue.number }}
       GITHUB_LABEL_NAME:
         description: 'The name of the label to remove.'
         required: true
@@ -50,7 +55,7 @@ jobs:
       - name: remove-label
         env:
           GH_REPOSITORY: ${{ github.repository }}
-          GH_ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_ISSUE_NUMBER: ${{ inputs.GITHUB_ISSUE_NUMBER }}
           GH_LABEL_NAME: ${{ inputs.GITHUB_LABEL_NAME }}
         run: |
           $MAKE github-remove-label \

--- a/.github/workflows/go-fmt.yaml
+++ b/.github/workflows/go-fmt.yaml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -33,6 +33,9 @@ jobs:
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
#### Features

- use repo and ref from PR HEAD for go-fmt, go-lint, go-test
- primus workflows to add/remove labels from issues/PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added two new GitHub Actions workflows:
		- `github-add-label` for automatically adding labels to GitHub issues
		- `github-remove-label` for removing labels from GitHub issues

- **Improvements**
	- Enhanced existing GitHub Actions workflows (`go-fmt`, `go-lint`, `go-test`) to dynamically check out specific pull request branches and repositories
<!-- end of auto-generated comment: release notes by coderabbit.ai -->