### PR TITLE
ci(github): update github-label workflow

### DIFF
--- a/.github/workflows/github-label.yaml
+++ b/.github/workflows/github-label.yaml
@@ -31,7 +31,7 @@ env:
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
 
 jobs:
-  signoz:
+  labeler:
     runs-on: ubuntu-latest
     permissions:
       contents: 'read'
@@ -63,10 +63,6 @@ jobs:
           GH_ISSUE_NUMBER: ${{ inputs.GITHUB_ISSUE_NUMBER }}
           GH_LABEL_NAME: ${{ inputs.GITHUB_LABEL_NAME }}
         run: |
-          if [[ "${GH_LABEL_ACTION}" != "add" && "${GH_LABEL_ACTION}" != "remove" ]]; then
-            echo "Invalid label action. Valid values are 'add' or 'remove'."
-            exit 1
-          fi
           GH_REPOSITORY_NAME=$(echo "${GH_REPOSITORY}" | awk -F'/' '{print $2}')
           $MAKE github-${GH_LABEL_ACTION}-label \
             GITHUB_ARGS="-t ${{ steps.token.outputs.token }} \


### PR DESCRIPTION
#### CI

- update github-label workflow 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration
	- Renamed job from `signoz` to `labeler`
	- Removed input validation step for label actions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->