### PR TITLE
ci(helm-unittest): use repo and ref from PR HEAD

### DIFF
--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -25,6 +25,9 @@ jobs:
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
#### CI

-helm-unittest: use repo and ref from PR HEAD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to improve pull request checkout process
	- Enhanced workflow's ability to dynamically reference pull request branches and repositories

<!-- end of auto-generated comment: release notes by coderabbit.ai -->