### PR TITLE
feat(build): support build/push for multiple providers

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -115,7 +115,7 @@ jobs:
           echo "GO_BUILD_FLAGS='${{ inputs.GO_BUILD_FLAGS }}'" >> $GITHUB_ENV
 
           # Docker build variables
-          echo "DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}'" >> $GITHUB_ENV
+          echo ''DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}''' >> $GITHUB_ENV
           echo "DOCKER_DOCKERFILE_PATH='${{ inputs.DOCKER_DOCKERFILE_PATH }}'" >> $GITHUB_ENV
 
           # Docker manifest variables

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -7,6 +7,18 @@ on:
         required: true
         default: 'main'
         type: string
+      GO_DOWNLOAD_ARTIFACT_NAME_PREFIX:
+        description: 'Prefix of the artifact to download. The artifact name will be ${GO_DOWNLOAD_ARTIFACT_NAME_PREFIX}-${{ github.sha }}.'
+        type: string
+      GO_DOWNLOAD_ARTIFACT_PATH:
+        description: 'Path of the artifact to download.'
+        type: string
+      GO_DOWNLOAD_ARTIFACT_REPO:
+        description: 'The repository to download the artifact from. If not provided, the default is the current repository.'
+        type: string
+      GO_DOWNLOAD_ARTIFACT_RUN_ID:
+        description: 'The run id of the artifact to download. If not provided, the default is the current run id.'
+        type: string
       GO_BUILD_CONTEXT:
         description: 'The directory path containing the main package.'
         required: true
@@ -14,6 +26,15 @@ on:
       GO_BUILD_FLAGS:
         description: 'Additional build flags to be passed.'
         required: true
+        type: string
+      GO_BUILD_PRE_FLAGS:
+        description: 'Additional build flags to be passed before the build. For example, "CGO_ENABLED=1" to enable CGO.'
+        type: string
+      GO_BUILD_PRE_FLAGS_ARM64:
+        description: 'Additional build flags to be passed before the build for arm64. For example, "CC=aarch64-linux-gnu-gcc" to use aarch64-linux-gnu-gcc as the compiler.'
+        type: string
+      GO_BUILD_PRE_FLAGS_AMD64:
+        description: 'Additional build flags to be passed before the build for amd64. For example, "CC=gcc" to use gcc as the compiler.'
         type: string
       DOCKER_BASE_IMAGES:
         description: 'List of docker base images in json.'
@@ -29,7 +50,6 @@ on:
         type: boolean
       DOCKER_PROVIDERS:
         description: 'The docker providers to use, separated by commas. (hub, gcp, aws)'
-        required: false
         default: 'hub'
         type: string
 
@@ -74,6 +94,14 @@ jobs:
       - name: info
         run: |
           $MAKE info
+      - name: download-artifact
+        if: ${{ inputs.GO_DOWNLOAD_ARTIFACT_NAME_PREFIX && inputs.GO_DOWNLOAD_ARTIFACT_PATH }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.GO_DOWNLOAD_ARTIFACT_NAME_PREFIX }}-${{ github.sha }}
+          path: ${{ inputs.GO_DOWNLOAD_ARTIFACT_PATH }}
+          repository: ${{ inputs.GO_DOWNLOAD_ARTIFACT_REPO || github.repository }}
+          run-id: ${{ inputs.GO_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
       - name: go-build
         run: |
           $MAKE go-build GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}"

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -145,8 +145,8 @@ jobs:
           for provider in "${PROVIDERS[@]}"; do
             echo "Building manifest for the $provider provider"
             if [ "${{ inputs.GO_NAME }}" != "" ]; then
-              $MAKE docker-login-$provider docker-push docker-manifest NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+              $MAKE docker-login-$provider docker-push docker-manifest NAME="${{ inputs.GO_NAME }}" DOCKER_PROVIDER="$provider" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
             else
-              $MAKE docker-login-$provider docker-push docker-manifest DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+              $MAKE docker-login-$provider docker-push docker-manifest DOCKER_PROVIDER="$provider" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
             fi
           done

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -47,7 +47,7 @@ on:
         required: true
         type: boolean
       DOCKER_PROVIDERS:
-        description: 'The docker providers to use, separated by commas. (hub, gcp, aws)'
+        description: 'The docker providers to use, separated by commas without spaces. (hub,gcp,aws)'
         default: 'hub'
         type: string
 
@@ -106,14 +106,14 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
       - name: go-build
         run: |
-          if [ -n "${{ inputs.GO_NAME }}" ]; then
+          if [ "${{ inputs.GO_NAME }}" != "" ]; then
             $MAKE go-build NAME="${{ inputs.GO_NAME }}" GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
           else
             $MAKE go-build GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
           fi
       - name: docker-build
         run: |
-          if [ -n "${{ inputs.GO_NAME }}" ]; then
+          if [ "${{ inputs.GO_NAME }}" != "" ]; then
             $MAKE docker-build NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
           else
             $MAKE docker-build DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
@@ -144,7 +144,7 @@ jobs:
           IFS=',' read -ra PROVIDERS <<< "${{ inputs.DOCKER_PROVIDERS }}"
           for provider in "${PROVIDERS[@]}"; do
             echo "Building manifest for the $provider provider"
-            if [ -n "${{ inputs.GO_NAME }}" ]; then
+            if [ "${{ inputs.GO_NAME }}" != "" ]; then
               $MAKE docker-login-$provider docker-push docker-manifest NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
             else
               $MAKE docker-login-$provider docker-push docker-manifest DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -100,6 +100,10 @@ jobs:
           path: ${{ inputs.GO_DOWNLOAD_ARTIFACT_PATH }}
           repository: ${{ inputs.GO_DOWNLOAD_ARTIFACT_REPO || github.repository }}
           run-id: ${{ inputs.GO_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
+      - name: cross-compilation-tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
       - name: go-build
         run: |
           $MAKE go-build NAME="${{ inputs.GO_NAME }}" GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -33,7 +33,7 @@ on:
       GO_CGO_ENABLED:
         description: 'Whether to enable CGO. Set to 1 to enable CGO. If not provided, the default is 0.'
         default: '0'
-        type: boolean
+        type: string
       DOCKER_BASE_IMAGES:
         description: 'List of docker base images in json.'
         required: true

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -10,6 +10,7 @@ on:
       GO_NAME:
         description: 'The name of the go project.'
         type: string
+        default: 'undefined'
       GO_DOWNLOAD_ARTIFACT_NAME:
         description: 'The artifact name to download.'
         type: string

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -27,6 +27,11 @@ on:
         description: 'Whether to push the docker image or not.'
         required: true
         type: boolean
+      DOCKER_PROVIDERS:
+        description: 'The docker providers to use, separated by commas. (hub, gcp, aws)'
+        required: false
+        default: 'hub'
+        type: string
 
 defaults:
   run:
@@ -35,7 +40,7 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   go:
     runs-on: ubuntu-latest
@@ -75,14 +80,16 @@ jobs:
       - name: docker-build
         run: |
           $MAKE docker-build DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
-      - name: gcp-signoz
+      - name: docker-auth
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
           echo "GCP_PROJECT_ID=$($MAKE signoz-gcp-project-id)" >> $GITHUB_ENV
           echo "GCP_WORKLOAD_IDENTITY_PROVIDER=$($MAKE signoz-gcp-workload-identity-provider)" >> $GITHUB_ENV
-          echo "GCP_SERVICE_ACCOUNT=$($MAKE signoz-gcp-service-account)" >> $GITHUB_ENV
+          echo "GCP_SERVICE_ACCOUNT=$($MAKE signoz-gcp-service-account)" >> $GITHUB_ENV"
+          echo "HUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+          echo "HUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
       - name: gcp-auth
-        if: ${{ inputs.DOCKER_MANIFEST }}
+        if: ${{ inputs.DOCKER_MANIFEST }} && contains(inputs.DOCKER_PROVIDERS, 'gcp')
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -93,4 +100,8 @@ jobs:
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          $MAKE docker-login-gcp docker-push docker-manifest DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          IFS=',' read -ra PROVIDERS <<< "${{ inputs.DOCKER_PROVIDERS }}"
+          for provider in "${PROVIDERS[@]}"; do
+            echo "Building manifest for the $provider provider"
+            $MAKE docker-login-$provider docker-push docker-manifest DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          done

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -7,6 +7,9 @@ on:
         required: true
         default: 'main'
         type: string
+      GO_NAME:
+        description: 'The name of the go project.'
+        type: string
       GO_DOWNLOAD_ARTIFACT_NAME:
         description: 'The artifact name to download.'
         type: string
@@ -104,10 +107,10 @@ jobs:
           run-id: ${{ inputs.GO_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
       - name: go-build
         run: |
-          $MAKE go-build GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}"
+          $MAKE go-build NAME="${{ inputs.GO_NAME }}" GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}"
       - name: docker-build
         run: |
-          $MAKE docker-build DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          $MAKE docker-build NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
       - name: docker-auth-credentials
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'hub') }}
         run: |
@@ -134,5 +137,5 @@ jobs:
           IFS=',' read -ra PROVIDERS <<< "${{ inputs.DOCKER_PROVIDERS }}"
           for provider in "${PROVIDERS[@]}"; do
             echo "Building manifest for the $provider provider"
-            $MAKE docker-login-$provider docker-push docker-manifest DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+            $MAKE docker-login-$provider docker-push docker-manifest NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
           done

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -30,15 +30,10 @@ on:
         description: 'Additional build flags to be passed.'
         required: true
         type: string
-      GO_BUILD_PRE_FLAGS:
-        description: 'Additional build flags to be passed before the build. For example, "CGO_ENABLED=1" to enable CGO.'
-        type: string
-      GO_BUILD_PRE_FLAGS_ARM64:
-        description: 'Additional build flags to be passed before the build for arm64. For example, "CC=aarch64-linux-gnu-gcc" to use aarch64-linux-gnu-gcc as the compiler.'
-        type: string
-      GO_BUILD_PRE_FLAGS_AMD64:
-        description: 'Additional build flags to be passed before the build for amd64. For example, "CC=gcc" to use gcc as the compiler.'
-        type: string
+      GO_CGO_ENABLED:
+        description: 'Whether to enable CGO. Set to 1 to enable CGO. If not provided, the default is 0.'
+        default: '0'
+        type: boolean
       DOCKER_BASE_IMAGES:
         description: 'List of docker base images in json.'
         required: true
@@ -107,7 +102,7 @@ jobs:
           run-id: ${{ inputs.GO_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
       - name: go-build
         run: |
-          $MAKE go-build NAME="${{ inputs.GO_NAME }}" GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}"
+          $MAKE go-build NAME="${{ inputs.GO_NAME }}" GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
       - name: docker-build
         run: |
           $MAKE docker-build NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -10,17 +10,17 @@ on:
       GO_NAME:
         description: 'The name of the go project.'
         type: string
-      GO_DOWNLOAD_ARTIFACT_NAME:
-        description: 'The artifact name to download.'
+      GO_INPUT_ARTIFACT_CACHE_KEY:
+        description: 'The key to cache the input artifacts.'
         type: string
-      GO_DOWNLOAD_ARTIFACT_PATH:
-        description: 'Path of the artifact to download.'
+      GO_INPUT_ARTIFACT_PATH:
+        description: 'The path to the input artifacts.'
         type: string
-      GO_DOWNLOAD_ARTIFACT_REPO:
-        description: 'The repository to download the artifact from. If not provided, the default is the current repository.'
+      GO_OUTPUT_ARTIFACT_CACHE_KEY:
+        description: 'The key to cache the output artifacts.'
         type: string
-      GO_DOWNLOAD_ARTIFACT_RUN_ID:
-        description: 'The run id of the artifact to download. If not provided, the default is the current run id.'
+      GO_OUTPUT_ARTIFACT_PATH:
+        description: 'The path to the output artifacts.'
         type: string
       GO_BUILD_CONTEXT:
         description: 'The directory path containing the main package.'
@@ -92,14 +92,12 @@ jobs:
       - name: info
         run: |
           $MAKE info
-      - name: download-artifact
-        if: ${{ inputs.GO_DOWNLOAD_ARTIFACT_NAME && inputs.GO_DOWNLOAD_ARTIFACT_PATH }}
-        uses: actions/download-artifact@v4
+      - name: input-artifacts-cache
+        if: ${{ inputs.GO_INPUT_ARTIFACT_CACHE_KEY }}
+        uses: actions/cache@v4
         with:
-          name: ${{ inputs.GO_DOWNLOAD_ARTIFACT_NAME }}
-          path: ${{ inputs.GO_DOWNLOAD_ARTIFACT_PATH }}
-          repository: ${{ inputs.GO_DOWNLOAD_ARTIFACT_REPO || github.repository }}
-          run-id: ${{ inputs.GO_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
+          key: ${{ inputs.GO_INPUT_ARTIFACT_CACHE_KEY }}
+          path: ${{ inputs.GO_INPUT_ARTIFACT_PATH }}
       - name: cross-compilation-tools
         run: |
           sudo apt-get update
@@ -124,6 +122,12 @@ jobs:
       - name: go-build
         run: |
           $MAKE go-build
+      - name: output-artifacts-cache
+        if: ${{ inputs.GO_OUTPUT_ARTIFACT_CACHE_KEY }}
+        uses: actions/cache@v4
+        with:
+          key: ${{ inputs.GO_OUTPUT_ARTIFACT_CACHE_KEY }}
+          path: ${{ inputs.GO_OUTPUT_ARTIFACT_PATH }}
       - name: docker-build
         run: |
           $MAKE docker-build

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -10,7 +10,6 @@ on:
       GO_NAME:
         description: 'The name of the go project.'
         type: string
-        default: 'undefined'
       GO_DOWNLOAD_ARTIFACT_NAME:
         description: 'The artifact name to download.'
         type: string
@@ -107,10 +106,18 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
       - name: go-build
         run: |
-          $MAKE go-build NAME="${{ inputs.GO_NAME }}" GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
+          if [ -n "${{ inputs.GO_NAME }}" ]; then
+            $MAKE go-build NAME="${{ inputs.GO_NAME }}" GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
+          else
+            $MAKE go-build GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
+          fi
       - name: docker-build
         run: |
-          $MAKE docker-build NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          if [ -n "${{ inputs.GO_NAME }}" ]; then
+            $MAKE docker-build NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          else
+            $MAKE docker-build DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          fi
       - name: docker-auth-credentials
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'hub') }}
         run: |
@@ -137,5 +144,9 @@ jobs:
           IFS=',' read -ra PROVIDERS <<< "${{ inputs.DOCKER_PROVIDERS }}"
           for provider in "${PROVIDERS[@]}"; do
             echo "Building manifest for the $provider provider"
-            $MAKE docker-login-$provider docker-push docker-manifest NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+            if [ -n "${{ inputs.GO_NAME }}" ]; then
+              $MAKE docker-login-$provider docker-push docker-manifest NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+            else
+              $MAKE docker-login-$provider docker-push docker-manifest DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+            fi
           done

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -130,8 +130,8 @@ jobs:
       - name: docker-auth
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
         run: |
-          echo "HUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
-          echo "HUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -104,19 +104,34 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
-      - name: go-build
+      - name: build-variables
         run: |
-          echo "GO_BUILD_CONTEXT=${{ inputs.GO_BUILD_CONTEXT }}" >> $GITHUB_ENV
-          echo "GO_BUILD_FLAGS=${{ inputs.GO_BUILD_FLAGS }}" >> $GITHUB_ENV
-          echo "GO_CGO_ENABLED=${{ inputs.GO_CGO_ENABLED }}" >> $GITHUB_ENV
+          # Go build variables
           if [ "${{ inputs.GO_NAME }}" != "" ]; then
             echo "GO_NAME=${{ inputs.GO_NAME }}" >> $GITHUB_ENV
+          fi
+          echo "GO_BUILD_CONTEXT=${{ inputs.GO_BUILD_CONTEXT }}" >> $GITHUB_ENV
+          echo "GO_CGO_ENABLED=${{ inputs.GO_CGO_ENABLED }}" >> $GITHUB_ENV
+          echo "GO_BUILD_FLAGS=${{ inputs.GO_BUILD_FLAGS }}" >> $GITHUB_ENV
+
+          # Docker build variables
+          echo "DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}" >> $GITHUB_ENV
+          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
+
+          # Docker manifest variables
+          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
+          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
+      - name: go-build
+        run: |
+          export GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}"
+          export GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
+          export GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}"
+          if [ "${{ inputs.GO_NAME }}" != "" ]; then
+            export GO_NAME="${{ inputs.GO_NAME }}"
           fi
           $MAKE go-build
       - name: docker-build
         run: |
-          echo "DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}" >> $GITHUB_ENV
-          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
           $MAKE docker-build
       - name: docker-auth
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
@@ -126,6 +141,4 @@ jobs:
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
-          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
           $MAKE docker-push docker-manifest

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -108,19 +108,19 @@ jobs:
         run: |
           # Go build variables
           if [ "${{ inputs.GO_NAME }}" != "" ]; then
-            echo "NAME='${{ inputs.GO_NAME }}'" >> $GITHUB_ENV
+            echo "NAME=${{ inputs.GO_NAME }}" >> $GITHUB_ENV
           fi
-          echo "GO_BUILD_CONTEXT='${{ inputs.GO_BUILD_CONTEXT }}'" >> $GITHUB_ENV
-          echo "GO_CGO_ENABLED='${{ inputs.GO_CGO_ENABLED }}'" >> $GITHUB_ENV
-          echo "GO_BUILD_FLAGS='${{ inputs.GO_BUILD_FLAGS }}'" >> $GITHUB_ENV
+          echo "GO_BUILD_CONTEXT=${{ inputs.GO_BUILD_CONTEXT }}" >> $GITHUB_ENV
+          echo "GO_CGO_ENABLED=${{ inputs.GO_CGO_ENABLED }}" >> $GITHUB_ENV
+          echo "GO_BUILD_FLAGS=${{ inputs.GO_BUILD_FLAGS }}" >> $GITHUB_ENV
 
           # Docker build variables
-          echo ''DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}''' >> $GITHUB_ENV
-          echo "DOCKER_DOCKERFILE_PATH='${{ inputs.DOCKER_DOCKERFILE_PATH }}'" >> $GITHUB_ENV
+          echo 'DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}' >> $GITHUB_ENV
+          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
 
           # Docker manifest variables
-          echo "DOCKER_MANIFEST='${{ inputs.DOCKER_MANIFEST }}'" >> $GITHUB_ENV
-          echo "DOCKER_PROVIDERS='${{ inputs.DOCKER_PROVIDERS }}'" >> $GITHUB_ENV
+          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
+          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
       - name: go-build
         run: |
           $MAKE go-build
@@ -130,8 +130,8 @@ jobs:
       - name: docker-auth
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
         run: |
-          echo "HUB_USERNAME='${{ secrets.DOCKERHUB_USERNAME }}'" >> $GITHUB_ENV
-          echo "HUB_TOKEN='${{ secrets.DOCKERHUB_TOKEN }}'" >> $GITHUB_ENV
+          echo "HUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+          echo "HUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -108,19 +108,19 @@ jobs:
         run: |
           # Go build variables
           if [ "${{ inputs.GO_NAME }}" != "" ]; then
-            echo "NAME=${{ inputs.GO_NAME }}" >> $GITHUB_ENV
+            echo "NAME='${{ inputs.GO_NAME }}'" >> $GITHUB_ENV
           fi
-          echo "GO_BUILD_CONTEXT=${{ inputs.GO_BUILD_CONTEXT }}" >> $GITHUB_ENV
-          echo "GO_CGO_ENABLED=${{ inputs.GO_CGO_ENABLED }}" >> $GITHUB_ENV
-          echo "GO_BUILD_FLAGS=${{ inputs.GO_BUILD_FLAGS }}" >> $GITHUB_ENV
+          echo "GO_BUILD_CONTEXT='${{ inputs.GO_BUILD_CONTEXT }}'" >> $GITHUB_ENV
+          echo "GO_CGO_ENABLED='${{ inputs.GO_CGO_ENABLED }}'" >> $GITHUB_ENV
+          echo "GO_BUILD_FLAGS='${{ inputs.GO_BUILD_FLAGS }}'" >> $GITHUB_ENV
 
           # Docker build variables
-          echo "DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}" >> $GITHUB_ENV
-          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
+          echo "DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}'" >> $GITHUB_ENV
+          echo "DOCKER_DOCKERFILE_PATH='${{ inputs.DOCKER_DOCKERFILE_PATH }}'" >> $GITHUB_ENV
 
           # Docker manifest variables
-          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
-          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
+          echo "DOCKER_MANIFEST='${{ inputs.DOCKER_MANIFEST }}'" >> $GITHUB_ENV
+          echo "DOCKER_PROVIDERS='${{ inputs.DOCKER_PROVIDERS }}'" >> $GITHUB_ENV
       - name: go-build
         run: |
           $MAKE go-build
@@ -130,8 +130,8 @@ jobs:
       - name: docker-auth
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
         run: |
-          echo "HUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
-          echo "HUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "HUB_USERNAME='${{ secrets.DOCKERHUB_USERNAME }}'" >> $GITHUB_ENV
+          echo "HUB_TOKEN='${{ secrets.DOCKERHUB_TOKEN }}'" >> $GITHUB_ENV
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -47,8 +47,8 @@ on:
         required: true
         type: boolean
       DOCKER_PROVIDERS:
-        description: 'The docker providers to use, separated by commas without spaces. (hub,gcp,aws)'
-        default: 'hub'
+        description: 'The docker providers to use, separated by spaces. (dockerhub gcp aws)'
+        default: 'dockerhub'
         type: string
 
 defaults:
@@ -106,47 +106,26 @@ jobs:
           sudo apt-get install -y gcc-aarch64-linux-gnu musl-tools
       - name: go-build
         run: |
+          echo "GO_BUILD_CONTEXT=${{ inputs.GO_BUILD_CONTEXT }}" >> $GITHUB_ENV
+          echo "GO_BUILD_FLAGS=${{ inputs.GO_BUILD_FLAGS }}" >> $GITHUB_ENV
+          echo "GO_CGO_ENABLED=${{ inputs.GO_CGO_ENABLED }}" >> $GITHUB_ENV
           if [ "${{ inputs.GO_NAME }}" != "" ]; then
-            $MAKE go-build NAME="${{ inputs.GO_NAME }}" GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
-          else
-            $MAKE go-build GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}" GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}" GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
+            echo "GO_NAME=${{ inputs.GO_NAME }}" >> $GITHUB_ENV
           fi
+          $MAKE go-build
       - name: docker-build
         run: |
-          if [ "${{ inputs.GO_NAME }}" != "" ]; then
-            $MAKE docker-build NAME="${{ inputs.GO_NAME }}" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
-          else
-            $MAKE docker-build DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
-          fi
-      - name: docker-auth-credentials
-        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'hub') }}
+          echo "DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}" >> $GITHUB_ENV
+          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
+          $MAKE docker-build
+      - name: docker-auth
+        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
         run: |
           echo "HUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
           echo "HUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
-      - name: gcp-auth-prepare
-        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'gcp') }}
-        run: |
-          echo "GCP_PROJECT_ID=$($MAKE signoz-gcp-project-id)" >> $GITHUB_ENV
-          echo "GCP_WORKLOAD_IDENTITY_PROVIDER=$($MAKE signoz-gcp-workload-identity-provider)" >> $GITHUB_ENV
-          echo "GCP_SERVICE_ACCOUNT=$($MAKE signoz-gcp-service-account)" >> $GITHUB_ENV
-      - name: gcp-auth
-        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'gcp') }}
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
-      - name: sdk-install
-        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'gcp') }}
-        uses: 'google-github-actions/setup-gcloud@v2'
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          IFS=',' read -ra PROVIDERS <<< "${{ inputs.DOCKER_PROVIDERS }}"
-          for provider in "${PROVIDERS[@]}"; do
-            echo "Building manifest for the $provider provider"
-            if [ "${{ inputs.GO_NAME }}" != "" ]; then
-              $MAKE docker-login-$provider docker-push docker-manifest NAME="${{ inputs.GO_NAME }}" DOCKER_PROVIDER="$provider" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
-            else
-              $MAKE docker-login-$provider docker-push docker-manifest DOCKER_PROVIDER="$provider" DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
-            fi
-          done
+          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
+          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
+          $MAKE docker-push docker-manifest

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -80,14 +80,14 @@ jobs:
       - name: docker-build
         run: |
           $MAKE docker-build DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
-      - name: docker-auth
+      - name: docker-auth-credentials
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          echo "GCP_PROJECT_ID=$($MAKE signoz-gcp-project-id)" >> $GITHUB_ENV
-          echo "GCP_WORKLOAD_IDENTITY_PROVIDER=$($MAKE signoz-gcp-workload-identity-provider)" >> $GITHUB_ENV
-          echo "GCP_SERVICE_ACCOUNT=$($MAKE signoz-gcp-service-account)" >> $GITHUB_ENV"
           echo "HUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
           echo "HUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "GCP_PROJECT_ID=$($MAKE signoz-gcp-project-id)" >> $GITHUB_ENV
+          echo "GCP_WORKLOAD_IDENTITY_PROVIDER=$($MAKE signoz-gcp-workload-identity-provider)" >> $GITHUB_ENV
+          echo "GCP_SERVICE_ACCOUNT=$($MAKE signoz-gcp-service-account)" >> $GITHUB_ENV
       - name: gcp-auth
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'gcp') }}
         uses: 'google-github-actions/auth@v2'

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -81,10 +81,13 @@ jobs:
         run: |
           $MAKE docker-build DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
       - name: docker-auth-credentials
-        if: ${{ inputs.DOCKER_MANIFEST }}
+        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'hub') }}
         run: |
           echo "HUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
           echo "HUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
+      - name: gcp-auth-prepare
+        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'gcp') }}
+        run: |
           echo "GCP_PROJECT_ID=$($MAKE signoz-gcp-project-id)" >> $GITHUB_ENV
           echo "GCP_WORKLOAD_IDENTITY_PROVIDER=$($MAKE signoz-gcp-workload-identity-provider)" >> $GITHUB_ENV
           echo "GCP_SERVICE_ACCOUNT=$($MAKE signoz-gcp-service-account)" >> $GITHUB_ENV
@@ -95,7 +98,7 @@ jobs:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
       - name: sdk-install
-        if: ${{ inputs.DOCKER_MANIFEST }}
+        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'gcp') }}
         uses: 'google-github-actions/setup-gcloud@v2'
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -108,7 +108,7 @@ jobs:
         run: |
           # Go build variables
           if [ "${{ inputs.GO_NAME }}" != "" ]; then
-            echo "GO_NAME=${{ inputs.GO_NAME }}" >> $GITHUB_ENV
+            echo "NAME=${{ inputs.GO_NAME }}" >> $GITHUB_ENV
           fi
           echo "GO_BUILD_CONTEXT=${{ inputs.GO_BUILD_CONTEXT }}" >> $GITHUB_ENV
           echo "GO_CGO_ENABLED=${{ inputs.GO_CGO_ENABLED }}" >> $GITHUB_ENV
@@ -123,12 +123,6 @@ jobs:
           echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
       - name: go-build
         run: |
-          export GO_BUILD_CONTEXT="${{ inputs.GO_BUILD_CONTEXT }}"
-          export GO_CGO_ENABLED="${{ inputs.GO_CGO_ENABLED }}"
-          export GO_BUILD_FLAGS="${{ inputs.GO_BUILD_FLAGS }}"
-          if [ "${{ inputs.GO_NAME }}" != "" ]; then
-            export GO_NAME="${{ inputs.GO_NAME }}"
-          fi
           $MAKE go-build
       - name: docker-build
         run: |
@@ -141,4 +135,4 @@ jobs:
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          $MAKE docker-push docker-manifest
+          $MAKE docker-login docker-push docker-manifest

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -135,4 +135,4 @@ jobs:
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          $MAKE docker-login docker-push docker-manifest
+          $MAKE docker-push docker-manifest

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -89,7 +89,7 @@ jobs:
           echo "HUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
           echo "HUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
       - name: gcp-auth
-        if: ${{ inputs.DOCKER_MANIFEST }} && contains(inputs.DOCKER_PROVIDERS, 'gcp')
+        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'gcp') }}
         uses: 'google-github-actions/auth@v2'
         with:
           workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -7,8 +7,8 @@ on:
         required: true
         default: 'main'
         type: string
-      GO_DOWNLOAD_ARTIFACT_NAME_PREFIX:
-        description: 'Prefix of the artifact to download. The artifact name will be ${GO_DOWNLOAD_ARTIFACT_NAME_PREFIX}-${{ github.sha }}.'
+      GO_DOWNLOAD_ARTIFACT_NAME:
+        description: 'The artifact name to download.'
         type: string
       GO_DOWNLOAD_ARTIFACT_PATH:
         description: 'Path of the artifact to download.'
@@ -95,10 +95,10 @@ jobs:
         run: |
           $MAKE info
       - name: download-artifact
-        if: ${{ inputs.GO_DOWNLOAD_ARTIFACT_NAME_PREFIX && inputs.GO_DOWNLOAD_ARTIFACT_PATH }}
+        if: ${{ inputs.GO_DOWNLOAD_ARTIFACT_NAME && inputs.GO_DOWNLOAD_ARTIFACT_PATH }}
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.GO_DOWNLOAD_ARTIFACT_NAME_PREFIX }}-${{ github.sha }}
+          name: ${{ inputs.GO_DOWNLOAD_ARTIFACT_NAME }}
           path: ${{ inputs.GO_DOWNLOAD_ARTIFACT_PATH }}
           repository: ${{ inputs.GO_DOWNLOAD_ARTIFACT_REPO || github.repository }}
           run-id: ${{ inputs.GO_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -7,6 +7,22 @@ on:
         required: true
         default: 'main'
         type: string
+      JS_WORKDIR:
+        description: 'The working directory. If not provided, the defaults to the root of the repository.'
+        type: string
+      JS_ENV_CONTENT:
+        description: 'Content of the env file.'
+        type: string
+      JS_UPLOAD_ARTIFACT_NAME_PREFIX:
+        description: 'Prefix of the artifact to upload. The artifact name will be ${JS_UPLOAD_ARTIFACT_NAME_PREFIX}-${{ github.sha }}.'
+        type: string
+      JS_UPLOAD_ARTIFACT_PATH:
+        description: 'Path of the artifact to upload.'
+        type: string
+      DOCKER_BUILD:
+        description: 'Whether to build the docker image or not.'
+        default: true
+        type: boolean
       DOCKER_BASE_IMAGES:
         description: 'List of docker base images in json.'
         required: true
@@ -22,6 +38,10 @@ on:
       DOCKER_ARCHS:
         description: 'List of architectures to build the docker image.'
         default: 'amd64 arm64'
+        type: string
+      DOCKER_PROVIDERS:
+        description: 'The docker providers to use, separated by commas. (hub, gcp, aws)'
+        default: 'hub'
         type: string
 
 defaults:
@@ -61,7 +81,21 @@ jobs:
       - name: info
         run: |
           $MAKE info
+      - name: create-env
+        if: ${{ inputs.JS_ENV_CONTENT }}
+        run: |
+          echo -e "${{ inputs.JS_ENV_CONTENT }}" >> ${{ inputs.JS_WORKDIR }}/.env
+      - name: js-build
+        run: |
+          $MAKE js-build
+      - name: upload-artifact
+        if: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME_PREFIX && inputs.JS_UPLOAD_ARTIFACT_PATH }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME_PREFIX }}-${{ github.sha }}
+          path: ${{ inputs.JS_UPLOAD_ARTIFACT_PATH }}
       - name: docker-build
+        if: ${{ inputs.DOCKER_BUILD }}
         run: |
           $MAKE docker-build DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
       - name: gcp-signoz
@@ -82,4 +116,8 @@ jobs:
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          $MAKE docker-login-gcp docker-push docker-manifest DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          IFS=',' read -ra PROVIDERS <<< "${{ inputs.DOCKER_PROVIDERS }}"
+          for provider in "${PROVIDERS[@]}"; do
+            echo "Building manifest for the $provider provider"
+            $MAKE docker-login-$provider docker-push docker-manifest DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          done

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -47,7 +47,7 @@ on:
         default: 'amd64 arm64'
         type: string
       DOCKER_PROVIDERS:
-        description: 'The docker providers to use, separated by commas. (hub, gcp, aws)'
+        description: 'The docker providers to use, separated by commas without spaces. (hub,gcp,aws)'
         default: 'hub'
         type: string
 defaults:

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -7,8 +7,8 @@ on:
         required: true
         default: 'main'
         type: string
-      JS_WORKDIR:
-        description: 'The working directory. If not provided, the defaults to the root of the repository.'
+      JS_SRC:
+        description: 'The path to the source directory. If not provided, the defaults to the root of the repository.'
         default: '.'
         type: string
       JS_DOTENV_CACHE_KEY:
@@ -87,10 +87,10 @@ jobs:
         uses: actions/cache@v4
         with:
           key: ${{ inputs.JS_DOTENV_CACHE_KEY }}
-          path: ${{ inputs.JS_WORKDIR }}/.env
+          path: ${{ inputs.JS_SRC }}/.env
       - name: js-build
         run: |
-          $MAKE js-build JS_WORKDIR='${{ inputs.JS_WORKDIR }}'
+          $MAKE js-build JS_SRC='${{ inputs.JS_SRC }}'
       - name: upload-artifact
         if: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME && inputs.JS_UPLOAD_ARTIFACT_PATH }}
         uses: actions/upload-artifact@v4
@@ -101,21 +101,6 @@ jobs:
         if: ${{ inputs.DOCKER_BUILD }}
         run: |
           $MAKE docker-build DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
-      - name: gcp-signoz
-        if: ${{ inputs.DOCKER_MANIFEST }}
-        run: |
-          echo "GCP_PROJECT_ID=$($MAKE signoz-gcp-project-id)" >> $GITHUB_ENV
-          echo "GCP_WORKLOAD_IDENTITY_PROVIDER=$($MAKE signoz-gcp-workload-identity-provider)" >> $GITHUB_ENV
-          echo "GCP_SERVICE_ACCOUNT=$($MAKE signoz-gcp-service-account)" >> $GITHUB_ENV
-      - name: gcp-auth
-        if: ${{ inputs.DOCKER_MANIFEST }}
-        uses: 'google-github-actions/auth@v2'
-        with:
-          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
-      - name: sdk-install
-        if: ${{ inputs.DOCKER_MANIFEST }}
-        uses: 'google-github-actions/setup-gcloud@v2'
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -10,8 +10,8 @@ on:
       JS_WORKDIR:
         description: 'The working directory. If not provided, the defaults to the root of the repository.'
         type: string
-      JS_DOWNLOAD_ARTIFACT_NAME_PREFIX:
-        description: 'Prefix of the artifact to download. The artifact name will be ${JS_DOWNLOAD_ARTIFACT_NAME_PREFIX}-${{ github.sha }}.'
+      JS_DOWNLOAD_ARTIFACT_NAME:
+        description: 'The artifact name to download.'
         type: string
       JS_DOWNLOAD_ARTIFACT_PATH:
         description: 'Path of the artifact to download.'
@@ -22,8 +22,8 @@ on:
       JS_DOWNLOAD_ARTIFACT_RUN_ID:
         description: 'The run id of the artifact to download. If not provided, the default is the current run id.'
         type: string
-      JS_UPLOAD_ARTIFACT_NAME_PREFIX:
-        description: 'Prefix of the artifact to upload. The artifact name will be ${JS_UPLOAD_ARTIFACT_NAME_PREFIX}-${{ github.sha }}.'
+      JS_UPLOAD_ARTIFACT_NAME:
+        description: 'The artifact name to upload.'
         type: string
       JS_UPLOAD_ARTIFACT_PATH:
         description: 'Path of the artifact to upload.'
@@ -90,10 +90,10 @@ jobs:
         run: |
           $MAKE info
       - name: download-artifact
-        if: ${{ inputs.JS_DOWNLOAD_ARTIFACT_NAME_PREFIX && inputs.JS_DOWNLOAD_ARTIFACT_PATH }}
+        if: ${{ inputs.JS_DOWNLOAD_ARTIFACT_NAME && inputs.JS_DOWNLOAD_ARTIFACT_PATH }}
         uses: actions/download-artifact@v4
         with:
-          name: ${{ inputs.JS_DOWNLOAD_ARTIFACT_NAME_PREFIX }}-${{ github.sha }}
+          name: ${{ inputs.JS_DOWNLOAD_ARTIFACT_NAME }}
           path: ${{ inputs.JS_DOWNLOAD_ARTIFACT_PATH }}
           repository: ${{ inputs.JS_DOWNLOAD_ARTIFACT_REPO || github.repository }}
           run-id: ${{ inputs.JS_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
@@ -101,10 +101,10 @@ jobs:
         run: |
           $MAKE js-build
       - name: upload-artifact
-        if: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME_PREFIX && inputs.JS_UPLOAD_ARTIFACT_PATH }}
+        if: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME && inputs.JS_UPLOAD_ARTIFACT_PATH }}
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME_PREFIX }}-${{ github.sha }}
+          name: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME }}
           path: ${{ inputs.JS_UPLOAD_ARTIFACT_PATH }}
       - name: docker-build
         if: ${{ inputs.DOCKER_BUILD }}

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -42,8 +42,8 @@ on:
         default: 'amd64 arm64'
         type: string
       DOCKER_PROVIDERS:
-        description: 'The docker providers to use, separated by commas without spaces. (hub,gcp,aws)'
-        default: 'hub'
+        description: 'The docker providers to use, separated by spaces. (dockerhub gcp aws)'
+        default: 'gcp'
         type: string
 defaults:
   run:
@@ -101,11 +101,13 @@ jobs:
         if: ${{ inputs.DOCKER_BUILD }}
         run: |
           $MAKE docker-build DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+      - name: docker-auth
+        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
+        run: |
+          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          IFS=',' read -ra PROVIDERS <<< "${{ inputs.DOCKER_PROVIDERS }}"
-          for provider in "${PROVIDERS[@]}"; do
-            echo "Building manifest for the $provider provider"
-            $MAKE docker-login-$provider docker-push docker-manifest DOCKER_PROVIDER="$provider" DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
-          done
+          echo "Building manifest for the $provider provider"
+          $MAKE docker-login docker-push docker-manifest DOCKER_PROVIDERS="${{ inputs.DOCKER_PROVIDERS }}" DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -88,9 +88,17 @@ jobs:
         with:
           key: ${{ inputs.JS_DOTENV_CACHE_KEY }}
           path: ${{ inputs.JS_SRC }}/.env
+      - name: build-variables
+        run: |
+          echo "JS_SRC=${{ inputs.JS_SRC }}" >> $GITHUB_ENV
+          echo "DOCKER_ARCHS=${{ inputs.DOCKER_ARCHS }}" >> $GITHUB_ENV
+          echo "DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}" >> $GITHUB_ENV
+          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
+          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
+          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
       - name: js-build
         run: |
-          $MAKE js-build JS_SRC='${{ inputs.JS_SRC }}'
+          $MAKE js-build
       - name: upload-artifact
         if: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME && inputs.JS_UPLOAD_ARTIFACT_PATH }}
         uses: actions/upload-artifact@v4
@@ -100,7 +108,7 @@ jobs:
       - name: docker-build
         if: ${{ inputs.DOCKER_BUILD }}
         run: |
-          $MAKE docker-build DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          $MAKE docker-build
       - name: docker-auth
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
         run: |
@@ -109,5 +117,4 @@ jobs:
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          echo "Building manifest for the $provider provider"
-          $MAKE docker-login docker-push docker-manifest DOCKER_PROVIDERS="${{ inputs.DOCKER_PROVIDERS }}" DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+          $MAKE docker-login docker-push docker-manifest

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -14,7 +14,6 @@ on:
       JS_DOTENV_CACHE_KEY:
         description: 'The key to cache the dotenv file.'
         type: string
-        required: true
       JS_DOWNLOAD_ARTIFACT_RUN_ID:
         description: 'The run id of the artifact to download. If not provided, the default is the current run id.'
         type: string
@@ -84,6 +83,7 @@ jobs:
         run: |
           $MAKE info
       - name: dotenv-cache
+        if: ${{ inputs.JS_DOTENV_CACHE_KEY }}
         uses: actions/cache@v4
         with:
           key: ${{ inputs.JS_DOTENV_CACHE_KEY }}

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -90,12 +90,12 @@ jobs:
           path: ${{ inputs.JS_SRC }}/.env
       - name: build-variables
         run: |
-          echo "JS_SRC='${{ inputs.JS_SRC }}'" >> $GITHUB_ENV
-          echo "DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}'" >> $GITHUB_ENV
-          echo ''DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}''' >> $GITHUB_ENV
-          echo "DOCKER_DOCKERFILE_PATH='${{ inputs.DOCKER_DOCKERFILE_PATH }}'" >> $GITHUB_ENV
-          echo "DOCKER_MANIFEST='${{ inputs.DOCKER_MANIFEST }}'" >> $GITHUB_ENV
-          echo "DOCKER_PROVIDERS='${{ inputs.DOCKER_PROVIDERS }}'" >> $GITHUB_ENV
+          echo "JS_SRC=${{ inputs.JS_SRC }}" >> $GITHUB_ENV
+          echo "DOCKER_ARCHS=${{ inputs.DOCKER_ARCHS }}" >> $GITHUB_ENV
+          echo 'DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}' >> $GITHUB_ENV
+          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
+          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
+          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
       - name: js-build
         run: |
           $MAKE js-build
@@ -112,8 +112,8 @@ jobs:
       - name: docker-auth
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
         run: |
-          echo "DOCKERHUB_USERNAME='${{ secrets.DOCKERHUB_USERNAME }}'" >> $GITHUB_ENV
-          echo "DOCKERHUB_TOKEN='${{ secrets.DOCKERHUB_TOKEN }}'" >> $GITHUB_ENV
+          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -34,11 +34,9 @@ on:
         type: boolean
       DOCKER_BASE_IMAGES:
         description: 'List of docker base images in json.'
-        required: true
         type: string
       DOCKER_DOCKERFILE_PATH:
         description: 'Path to dockerfile.'
-        required: true
         type: string
       DOCKER_MANIFEST:
         description: 'Whether to push the docker image or not.'

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -9,16 +9,12 @@ on:
         type: string
       JS_WORKDIR:
         description: 'The working directory. If not provided, the defaults to the root of the repository.'
+        default: '.'
         type: string
-      JS_DOWNLOAD_ARTIFACT_NAME:
-        description: 'The artifact name to download.'
+      JS_DOTENV_CACHE_KEY:
+        description: 'The key to cache the dotenv file.'
         type: string
-      JS_DOWNLOAD_ARTIFACT_PATH:
-        description: 'Path of the artifact to download.'
-        type: string
-      JS_DOWNLOAD_ARTIFACT_REPO:
-        description: 'The repository to download the artifact from. If not provided, the default is the current repository.'
-        type: string
+        required: true
       JS_DOWNLOAD_ARTIFACT_RUN_ID:
         description: 'The run id of the artifact to download. If not provided, the default is the current run id.'
         type: string
@@ -87,14 +83,11 @@ jobs:
       - name: info
         run: |
           $MAKE info
-      - name: download-artifact
-        if: ${{ inputs.JS_DOWNLOAD_ARTIFACT_NAME && inputs.JS_DOWNLOAD_ARTIFACT_PATH }}
-        uses: actions/download-artifact@v4
+      - name: dotenv-cache
+        uses: actions/cache@v4
         with:
-          name: ${{ inputs.JS_DOWNLOAD_ARTIFACT_NAME }}
-          path: ${{ inputs.JS_DOWNLOAD_ARTIFACT_PATH }}
-          repository: ${{ inputs.JS_DOWNLOAD_ARTIFACT_REPO || github.repository }}
-          run-id: ${{ inputs.JS_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
+          key: ${{ inputs.JS_DOTENV_CACHE_KEY }}
+          path: ${{ inputs.JS_WORKDIR }}/.env
       - name: js-build
         run: |
           $MAKE js-build JS_WORKDIR='${{ inputs.JS_WORKDIR }}'

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -129,5 +129,5 @@ jobs:
           IFS=',' read -ra PROVIDERS <<< "${{ inputs.DOCKER_PROVIDERS }}"
           for provider in "${PROVIDERS[@]}"; do
             echo "Building manifest for the $provider provider"
-            $MAKE docker-login-$provider docker-push docker-manifest DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
+            $MAKE docker-login-$provider docker-push docker-manifest DOCKER_PROVIDER="$provider" DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}' DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}' DOCKER_DOCKERFILE_PATH="${{ inputs.DOCKER_DOCKERFILE_PATH }}"
           done

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -97,7 +97,7 @@ jobs:
           run-id: ${{ inputs.JS_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
       - name: js-build
         run: |
-          $MAKE js-build
+          $MAKE js-build JS_WORKDIR='${{ inputs.JS_WORKDIR }}'
       - name: upload-artifact
         if: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME && inputs.JS_UPLOAD_ARTIFACT_PATH }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -117,4 +117,4 @@ jobs:
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |
-          $MAKE docker-login docker-push docker-manifest
+          $MAKE docker-push docker-manifest

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -10,8 +10,17 @@ on:
       JS_WORKDIR:
         description: 'The working directory. If not provided, the defaults to the root of the repository.'
         type: string
-      JS_ENV_CONTENT:
-        description: 'Content of the env file.'
+      JS_DOWNLOAD_ARTIFACT_NAME_PREFIX:
+        description: 'Prefix of the artifact to download. The artifact name will be ${JS_DOWNLOAD_ARTIFACT_NAME_PREFIX}-${{ github.sha }}.'
+        type: string
+      JS_DOWNLOAD_ARTIFACT_PATH:
+        description: 'Path of the artifact to download.'
+        type: string
+      JS_DOWNLOAD_ARTIFACT_REPO:
+        description: 'The repository to download the artifact from. If not provided, the default is the current repository.'
+        type: string
+      JS_DOWNLOAD_ARTIFACT_RUN_ID:
+        description: 'The run id of the artifact to download. If not provided, the default is the current run id.'
         type: string
       JS_UPLOAD_ARTIFACT_NAME_PREFIX:
         description: 'Prefix of the artifact to upload. The artifact name will be ${JS_UPLOAD_ARTIFACT_NAME_PREFIX}-${{ github.sha }}.'
@@ -43,7 +52,6 @@ on:
         description: 'The docker providers to use, separated by commas. (hub, gcp, aws)'
         default: 'hub'
         type: string
-
 defaults:
   run:
     shell: bash
@@ -81,10 +89,14 @@ jobs:
       - name: info
         run: |
           $MAKE info
-      - name: create-env
-        if: ${{ inputs.JS_ENV_CONTENT }}
-        run: |
-          echo -e "${{ inputs.JS_ENV_CONTENT }}" >> ${{ inputs.JS_WORKDIR }}/.env
+      - name: download-artifact
+        if: ${{ inputs.JS_DOWNLOAD_ARTIFACT_NAME_PREFIX && inputs.JS_DOWNLOAD_ARTIFACT_PATH }}
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.JS_DOWNLOAD_ARTIFACT_NAME_PREFIX }}-${{ github.sha }}
+          path: ${{ inputs.JS_DOWNLOAD_ARTIFACT_PATH }}
+          repository: ${{ inputs.JS_DOWNLOAD_ARTIFACT_REPO || github.repository }}
+          run-id: ${{ inputs.JS_DOWNLOAD_ARTIFACT_RUN_ID || github.run_id }}
       - name: js-build
         run: |
           $MAKE js-build

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -90,12 +90,12 @@ jobs:
           path: ${{ inputs.JS_SRC }}/.env
       - name: build-variables
         run: |
-          echo "JS_SRC=${{ inputs.JS_SRC }}" >> $GITHUB_ENV
-          echo "DOCKER_ARCHS=${{ inputs.DOCKER_ARCHS }}" >> $GITHUB_ENV
-          echo "DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}" >> $GITHUB_ENV
-          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
-          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
-          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
+          echo "JS_SRC='${{ inputs.JS_SRC }}'" >> $GITHUB_ENV
+          echo "DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}'" >> $GITHUB_ENV
+          echo "DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}'" >> $GITHUB_ENV
+          echo "DOCKER_DOCKERFILE_PATH='${{ inputs.DOCKER_DOCKERFILE_PATH }}'" >> $GITHUB_ENV
+          echo "DOCKER_MANIFEST='${{ inputs.DOCKER_MANIFEST }}'" >> $GITHUB_ENV
+          echo "DOCKER_PROVIDERS='${{ inputs.DOCKER_PROVIDERS }}'" >> $GITHUB_ENV
       - name: js-build
         run: |
           $MAKE js-build
@@ -112,8 +112,8 @@ jobs:
       - name: docker-auth
         if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
         run: |
-          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
-          echo "DOCKERHUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_USERNAME='${{ secrets.DOCKERHUB_USERNAME }}'" >> $GITHUB_ENV
+          echo "DOCKERHUB_TOKEN='${{ secrets.DOCKERHUB_TOKEN }}'" >> $GITHUB_ENV
       - name: docker-manifest
         if: ${{ inputs.DOCKER_MANIFEST }}
         run: |

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -92,7 +92,7 @@ jobs:
         run: |
           echo "JS_SRC='${{ inputs.JS_SRC }}'" >> $GITHUB_ENV
           echo "DOCKER_ARCHS='${{ inputs.DOCKER_ARCHS }}'" >> $GITHUB_ENV
-          echo "DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}'" >> $GITHUB_ENV
+          echo ''DOCKER_BASE_IMAGES='${{ inputs.DOCKER_BASE_IMAGES }}''' >> $GITHUB_ENV
           echo "DOCKER_DOCKERFILE_PATH='${{ inputs.DOCKER_DOCKERFILE_PATH }}'" >> $GITHUB_ENV
           echo "DOCKER_MANIFEST='${{ inputs.DOCKER_MANIFEST }}'" >> $GITHUB_ENV
           echo "DOCKER_PROVIDERS='${{ inputs.DOCKER_PROVIDERS }}'" >> $GITHUB_ENV

--- a/.github/workflows/js-build.yaml
+++ b/.github/workflows/js-build.yaml
@@ -11,17 +11,17 @@ on:
         description: 'The path to the source directory. If not provided, the defaults to the root of the repository.'
         default: '.'
         type: string
-      JS_DOTENV_CACHE_KEY:
-        description: 'The key to cache the dotenv file.'
+      JS_INPUT_ARTIFACT_CACHE_KEY:
+        description: 'The key to cache the input artifacts.'
         type: string
-      JS_DOWNLOAD_ARTIFACT_RUN_ID:
-        description: 'The run id of the artifact to download. If not provided, the default is the current run id.'
+      JS_INPUT_ARTIFACT_PATH:
+        description: 'The path to the input artifacts.'
         type: string
-      JS_UPLOAD_ARTIFACT_NAME:
-        description: 'The artifact name to upload.'
+      JS_OUTPUT_ARTIFACT_CACHE_KEY:
+        description: 'The key to cache the output artifacts.'
         type: string
-      JS_UPLOAD_ARTIFACT_PATH:
-        description: 'Path of the artifact to upload.'
+      JS_OUTPUT_ARTIFACT_PATH:
+        description: 'The path to the output artifacts.'
         type: string
       DOCKER_BUILD:
         description: 'Whether to build the docker image or not.'
@@ -82,12 +82,12 @@ jobs:
       - name: info
         run: |
           $MAKE info
-      - name: dotenv-cache
-        if: ${{ inputs.JS_DOTENV_CACHE_KEY }}
+      - name: input-artifacts-cache
+        if: ${{ inputs.JS_INPUT_ARTIFACT_CACHE_KEY }}
         uses: actions/cache@v4
         with:
-          key: ${{ inputs.JS_DOTENV_CACHE_KEY }}
-          path: ${{ inputs.JS_SRC }}/.env
+          key: ${{ inputs.JS_INPUT_ARTIFACT_CACHE_KEY }}
+          path: ${{ inputs.JS_INPUT_ARTIFACT_PATH }}
       - name: build-variables
         run: |
           echo "JS_SRC=${{ inputs.JS_SRC }}" >> $GITHUB_ENV
@@ -99,12 +99,12 @@ jobs:
       - name: js-build
         run: |
           $MAKE js-build
-      - name: upload-artifact
-        if: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME && inputs.JS_UPLOAD_ARTIFACT_PATH }}
-        uses: actions/upload-artifact@v4
+      - name: output-artifacts-cache
+        if: ${{ inputs.JS_OUTPUT_ARTIFACT_CACHE_KEY }}
+        uses: actions/cache@v4
         with:
-          name: ${{ inputs.JS_UPLOAD_ARTIFACT_NAME }}
-          path: ${{ inputs.JS_UPLOAD_ARTIFACT_PATH }}
+          key: ${{ inputs.JS_OUTPUT_ARTIFACT_CACHE_KEY }}
+          path: ${{ inputs.JS_OUTPUT_ARTIFACT_PATH }}
       - name: docker-build
         if: ${{ inputs.DOCKER_BUILD }}
         run: |


### PR DESCRIPTION
#### Features

- support build/push for multiple providers for `go-build` and `js-build`
- support input/output artifacts for build workflows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced several new input parameters for enhanced configurability in workflows, including `GO_NAME`, `GO_INPUT_ARTIFACT_CACHE_KEY`, `GO_INPUT_ARTIFACT_PATH`, `GO_OUTPUT_ARTIFACT_CACHE_KEY`, `GO_OUTPUT_ARTIFACT_PATH`, `DOCKER_PROVIDERS`, `JS_SRC`, and `DOCKER_BUILD`.
	- Added steps for caching input and output artifacts, improving artifact management.
	- Enhanced Docker authentication and manifest publishing processes to dynamically adjust based on the selected providers.
- **Bug Fixes**
	- Updated conditions for Docker authentication to ensure proper execution based on specified providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->