### PR TITLE
feat(go): support custom Golang version

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         default: 'main'
         type: string
+      GO_VERSION:
+        description: 'The go version to use.'
+        required: false
+        default: '1.22'
+        type: string
       GO_NAME:
         description: 'The name of the go project.'
         type: string
@@ -88,7 +93,7 @@ jobs:
       - name: go-install
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: ${{ inputs.GO_VERSION }}
       - name: info
         run: |
           $MAKE info

--- a/.github/workflows/go-fmt.yaml
+++ b/.github/workflows/go-fmt.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         default: 'main'
         type: string
+      GO_VERSION:
+        description: 'The go version to use.'
+        required: false
+        default: '1.22'
+        type: string
 
 defaults:
   run:
@@ -45,7 +50,7 @@ jobs:
       - name: go-install
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: ${{ inputs.GO_VERSION }}
       - name: info
         run: |
           $MAKE info

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         default: 'main'
         type: string
+      GO_VERSION:
+        description: 'The go version to use.'
+        required: false
+        default: '1.22'
+        type: string
 
 defaults:
   run:
@@ -45,7 +50,7 @@ jobs:
       - name: go-install
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: ${{ inputs.GO_VERSION }}
       - name: info
         run: |
           $MAKE info

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -7,6 +7,11 @@ on:
         required: true
         default: 'main'
         type: string
+      GO_VERSION:
+        description: 'The go version to use.'
+        required: false
+        default: '1.22'
+        type: string
       GO_TEST_CONTEXT:
         description: 'The directory path containing the test packages.'
         required: true
@@ -53,7 +58,7 @@ jobs:
       - name: go-install
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: ${{ inputs.GO_VERSION }}
       - name: info
         run: |
           $MAKE info


### PR DESCRIPTION
#### Features

- support custom Golang version

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Made the Go version configurable in build, format, lint, and test workflows by introducing an optional input for specifying the Go version, with a default set to 1.22. This allows greater flexibility when running workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->