### PR TITLE
chore: support for merge queues

### DIFF
--- a/.github/workflows/github-label.yaml
+++ b/.github/workflows/github-label.yaml
@@ -16,11 +16,6 @@ on:
         description: 'The action to perform on the label. Valid values are "add" or "remove".'
         required: true
         type: string
-      GITHUB_ISSUE_NUMBER:
-        description: 'The issue number to add/remove the label from.'
-        required: false
-        type: string
-        default: ${{ github.event.pull_request.number || github.event.issue.number }}
       GITHUB_LABEL_NAME:
         description: 'The name of the label to add/remove.'
         required: true
@@ -60,11 +55,19 @@ jobs:
       - name: info
         run: |
           $MAKE info
+      - name: get-pr-number
+        id: pr
+        run: |
+          if [ "${{ github.event_name }}" = "merge_group" ]; then
+            echo "number=$(echo '${{ github.ref }}' | grep -oP 'pr-\K[0-9]+')" >> $GITHUB_OUTPUT
+          else
+            echo "number=${{ github.event.pull_request.number || github.event.issue.number }}" >> $GITHUB_OUTPUT
+          fi
       - name: label
         env:
           GH_LABEL_ACTION: ${{ inputs.GITHUB_LABEL_ACTION }}
           GH_REPOSITORY: ${{ github.repository }}
-          GH_ISSUE_NUMBER: ${{ inputs.GITHUB_ISSUE_NUMBER }}
+          GH_ISSUE_NUMBER: ${{ steps.pr.outputs.number }}
           GH_LABEL_NAME: ${{ inputs.GITHUB_LABEL_NAME }}
         run: |
           GH_REPOSITORY_NAME=$(echo "${GH_REPOSITORY}" | awk -F'/' '{print $2}')

--- a/.github/workflows/go-deps.yaml
+++ b/.github/workflows/go-deps.yaml
@@ -3,14 +3,14 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
       GO_VERSION:
-        description: 'The go version to use.'
+        description: "The go version to use."
         required: false
-        default: '1.22'
+        default: "1.22"
         type: string
 
 defaults:
@@ -20,19 +20,19 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   go:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/go-fmt.yaml
+++ b/.github/workflows/go-fmt.yaml
@@ -3,14 +3,14 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
       GO_VERSION:
-        description: 'The go version to use.'
+        description: "The go version to use."
         required: false
-        default: '1.22'
+        default: "1.22"
         type: string
 
 defaults:
@@ -20,19 +20,19 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   go:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/go-lint.yaml
+++ b/.github/workflows/go-lint.yaml
@@ -3,14 +3,14 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
       GO_VERSION:
-        description: 'The go version to use.'
+        description: "The go version to use."
         required: false
-        default: '1.22'
+        default: "1.22"
         type: string
 
 defaults:
@@ -20,19 +20,19 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   go:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/go-test.yaml
+++ b/.github/workflows/go-test.yaml
@@ -3,21 +3,21 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
       GO_VERSION:
-        description: 'The go version to use.'
+        description: "The go version to use."
         required: false
-        default: '1.22'
+        default: "1.22"
         type: string
       GO_TEST_CONTEXT:
-        description: 'The directory path containing the test packages.'
+        description: "The directory path containing the test packages."
         required: true
         type: string
       GO_TEST_TAGS:
-        description: 'Additional test tags to be passed.'
+        description: "Additional test tags to be passed."
         required: false
         type: string
 
@@ -28,19 +28,19 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   go:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/helm-unittest.yaml
+++ b/.github/workflows/helm-unittest.yaml
@@ -3,9 +3,9 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
 
 defaults:
@@ -15,19 +15,19 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   helm:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/js-fmt.yaml
+++ b/.github/workflows/js-fmt.yaml
@@ -3,17 +3,17 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
       NODE_VERSION:
-        description: 'The node version to use.'
+        description: "The node version to use."
         required: false
-        default: '22'
+        default: "22"
         type: string
       JS_SRC:
-        description: 'The directory path containing the js source code.'
+        description: "The directory path containing the js source code."
         required: true
         type: string
 
@@ -24,19 +24,19 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   js:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/js-lint.yaml
+++ b/.github/workflows/js-lint.yaml
@@ -3,17 +3,17 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
       NODE_VERSION:
-        description: 'The node version to use.'
+        description: "The node version to use."
         required: false
-        default: '22'
+        default: "22"
         type: string
       JS_SRC:
-        description: 'The directory path containing the js source code.'
+        description: "The directory path containing the js source code."
         required: true
         type: string
 
@@ -24,19 +24,19 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   js:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/js-test.yaml
+++ b/.github/workflows/js-test.yaml
@@ -3,17 +3,17 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
       NODE_VERSION:
-        description: 'The node version to use.'
+        description: "The node version to use."
         required: false
-        default: '22'
+        default: "22"
         type: string
       JS_SRC:
-        description: 'The directory path containing the js source code.'
+        description: "The directory path containing the js source code."
         required: true
         type: string
 
@@ -24,19 +24,19 @@ defaults:
 env:
   PRIMUS_HOME: .primus
   MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
-  
+
 jobs:
   js:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/js-tsc.yaml
+++ b/.github/workflows/js-tsc.yaml
@@ -3,17 +3,17 @@ on:
   workflow_call:
     inputs:
       PRIMUS_REF:
-        description: 'The primus ref to checkout.'
+        description: "The primus ref to checkout."
         required: true
-        default: 'main'
+        default: "main"
         type: string
       NODE_VERSION:
-        description: 'The node version to use.'
+        description: "The node version to use."
         required: false
-        default: '22'
+        default: "22"
         type: string
       JS_SRC:
-        description: 'The directory path containing the js source code.'
+        description: "The directory path containing the js source code."
         required: true
         type: string
 
@@ -29,14 +29,14 @@ jobs:
   js:
     runs-on: ubuntu-latest
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
Current PR process requires some amount of context switching to get a PR merged. Especially so during busy working hours. Goal with the merge queue is to reduce that time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflows with robust fallback for pull-request vs non-PR contexts and a computed PR-number output.
  * Removed the previous public GITHUB_ISSUE_NUMBER input.
  * Standardized YAML formatting and added token-based checkout plus additional setup steps to support Go, Node, Helm, lint, format and test targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->