### PR TITLE
feat(py): add py-build, py-fmt, py-lint, py-type-check, py-test workflows

### DIFF
--- a/.github/workflows/py-build.yaml
+++ b/.github/workflows/py-build.yaml
@@ -1,0 +1,120 @@
+name: py-build
+on:
+  workflow_call:
+    inputs:
+      PRIMUS_REF:
+        description: 'The primus ref to checkout.'
+        required: true
+        default: 'main'
+        type: string
+      PYTHON_VERSION:
+        description: 'The python version to use.'
+        required: false
+        default: '3.12'
+        type: string
+      PY_SRC:
+        description: 'The path to the source directory. If not provided, the defaults to the root of the repository.'
+        default: '.'
+        type: string
+      PY_PKG_MANAGER:
+        description: 'The python package manager to use.'
+        default: 'uv'
+        type: string
+      DOCKER_BUILD:
+        description: 'Whether to build the docker image or not.'
+        default: true
+        type: boolean
+      DOCKER_BASE_IMAGES:
+        description: 'List of docker base images in json.'
+        type: string
+      DOCKER_DOCKERFILE_PATH:
+        description: 'Path to dockerfile.'
+        type: string
+      DOCKER_MANIFEST:
+        description: 'Whether to push the docker image or not.'
+        required: true
+        type: boolean
+      DOCKER_ARCHS:
+        description: 'List of architectures to build the docker image.'
+        default: 'amd64 arm64'
+        type: string
+      DOCKER_PROVIDERS:
+        description: 'The docker providers to use, separated by spaces. (dockerhub gcp aws)'
+        default: 'gcp'
+        type: string
+      DOCKER_DOCKERHUB_TAG_LATEST:
+        description: 'Whether to push the latest tag or not to dockerhub. Works only when dockerhub has been set as a provider.'
+        required: false
+        type: boolean
+        default: true
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
+jobs:
+  py:
+    runs-on: ubuntu-latest
+    environment: ${{ github.ref_type == 'tag' && 'production' || github.ref_name == 'main' && 'staging' || 'review' }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: qemu-install
+        uses: docker/setup-qemu-action@v3
+      - name: python-install
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.PYTHON_VERSION }}
+      - name: uv-install
+        if: ${{ inputs.PY_PKG_MANAGER == 'uv' }}
+        uses: astral-sh/setup-uv@v6
+      - name: info
+        run: |
+          $MAKE info
+      - name: build-variables
+        run: |
+          echo "PY_SRC=${{ inputs.PY_SRC }}" >> $GITHUB_ENV
+          echo "PY_PKG_MANAGER=${{ inputs.PY_PKG_MANAGER }}" >> $GITHUB_ENV
+          echo "DOCKER_ARCHS=${{ inputs.DOCKER_ARCHS }}" >> $GITHUB_ENV
+          echo 'DOCKER_BASE_IMAGES=${{ inputs.DOCKER_BASE_IMAGES }}' >> $GITHUB_ENV
+          echo "DOCKER_DOCKERFILE_PATH=${{ inputs.DOCKER_DOCKERFILE_PATH }}" >> $GITHUB_ENV
+          echo "DOCKER_MANIFEST=${{ inputs.DOCKER_MANIFEST }}" >> $GITHUB_ENV
+          echo "DOCKER_PROVIDERS=${{ inputs.DOCKER_PROVIDERS }}" >> $GITHUB_ENV
+      - name: docker-build
+        if: ${{ inputs.DOCKER_BUILD }}
+        run: |
+          $MAKE docker-build
+      - name: docker-auth
+        if: ${{ inputs.DOCKER_MANIFEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
+        run: |
+          echo "DOCKERHUB_USERNAME=${{ secrets.DOCKERHUB_USERNAME }}" >> $GITHUB_ENV
+          echo "DOCKERHUB_TOKEN=${{ secrets.DOCKERHUB_TOKEN }}" >> $GITHUB_ENV
+      - name: docker-manifest
+        if: ${{ inputs.DOCKER_MANIFEST }}
+        run: |
+          $MAKE docker-push docker-manifest
+      - name: docker-latest
+        if: ${{ inputs.DOCKER_MANIFEST && inputs.DOCKER_DOCKERHUB_TAG_LATEST && contains(inputs.DOCKER_PROVIDERS, 'dockerhub') }}
+        run: |
+          $MAKE docker-push-dockerhub docker-manifest-dockerhub DOCKER_IMAGE_TAG=latest

--- a/.github/workflows/py-fmt.yaml
+++ b/.github/workflows/py-fmt.yaml
@@ -68,6 +68,4 @@ jobs:
           $MAKE info
       - name: py-fmt
         run: |
-          $MAKE py-fmt SRC="$(pwd)/${{ inputs.PY_SRC }}"
-        env:
-          PY_PKG_MANAGER: ${{ inputs.PY_PKG_MANAGER }}
+          $MAKE py-fmt SRC="$(pwd)/${{ inputs.PY_SRC }}" PY_PKG_MANAGER="${{ inputs.PY_PKG_MANAGER }}"

--- a/.github/workflows/py-fmt.yaml
+++ b/.github/workflows/py-fmt.yaml
@@ -1,0 +1,73 @@
+name: py-fmt
+on:
+  workflow_call:
+    inputs:
+      PRIMUS_REF:
+        description: 'The primus ref to checkout.'
+        required: true
+        default: 'main'
+        type: string
+      PYTHON_VERSION:
+        description: 'The python version to use.'
+        required: false
+        default: '3.12'
+        type: string
+      PY_SRC:
+        description: 'The directory path containing the py source code.'
+        required: true
+        type: string
+      PY_PKG_MANAGER:
+        description: 'The python package manager to use.'
+        required: false
+        default: 'uv'
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
+jobs:
+  py:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: python-install
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.PYTHON_VERSION }}
+      - name: uv-install
+        if: ${{ inputs.PY_PKG_MANAGER == 'uv' }}
+        uses: astral-sh/setup-uv@v6
+      - name: info
+        run: |
+          $MAKE info
+      - name: py-fmt
+        run: |
+          $MAKE py-fmt SRC="$(pwd)/${{ inputs.PY_SRC }}"
+        env:
+          PY_PKG_MANAGER: ${{ inputs.PY_PKG_MANAGER }}

--- a/.github/workflows/py-lint.yaml
+++ b/.github/workflows/py-lint.yaml
@@ -1,0 +1,73 @@
+name: py-lint
+on:
+  workflow_call:
+    inputs:
+      PRIMUS_REF:
+        description: 'The primus ref to checkout.'
+        required: true
+        default: 'main'
+        type: string
+      PYTHON_VERSION:
+        description: 'The python version to use.'
+        required: false
+        default: '3.12'
+        type: string
+      PY_SRC:
+        description: 'The directory path containing the py source code.'
+        required: true
+        type: string
+      PY_PKG_MANAGER:
+        description: 'The python package manager to use.'
+        required: false
+        default: 'uv'
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
+jobs:
+  py:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: python-install
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.PYTHON_VERSION }}
+      - name: uv-install
+        if: ${{ inputs.PY_PKG_MANAGER == 'uv' }}
+        uses: astral-sh/setup-uv@v6
+      - name: info
+        run: |
+          $MAKE info
+      - name: py-lint
+        run: |
+          $MAKE py-lint SRC="$(pwd)/${{ inputs.PY_SRC }}"
+        env:
+          PY_PKG_MANAGER: ${{ inputs.PY_PKG_MANAGER }}

--- a/.github/workflows/py-lint.yaml
+++ b/.github/workflows/py-lint.yaml
@@ -68,6 +68,4 @@ jobs:
           $MAKE info
       - name: py-lint
         run: |
-          $MAKE py-lint SRC="$(pwd)/${{ inputs.PY_SRC }}"
-        env:
-          PY_PKG_MANAGER: ${{ inputs.PY_PKG_MANAGER }}
+          $MAKE py-lint SRC="$(pwd)/${{ inputs.PY_SRC }}" PY_PKG_MANAGER="${{ inputs.PY_PKG_MANAGER }}"

--- a/.github/workflows/py-test.yaml
+++ b/.github/workflows/py-test.yaml
@@ -21,6 +21,11 @@ on:
         required: false
         default: 'uv'
         type: string
+      PY_TEST_FLAGS:
+        description: 'Additional flags and paths to pass to pytest (e.g. specific test files, --ignore, -m markers).'
+        required: false
+        default: ''
+        type: string
 
 defaults:
   run:
@@ -68,6 +73,4 @@ jobs:
           $MAKE info
       - name: py-test
         run: |
-          $MAKE py-test SRC="$(pwd)/${{ inputs.PY_SRC }}"
-        env:
-          PY_PKG_MANAGER: ${{ inputs.PY_PKG_MANAGER }}
+          $MAKE py-test SRC="$(pwd)/${{ inputs.PY_SRC }}" PY_PKG_MANAGER="${{ inputs.PY_PKG_MANAGER }}" PY_TEST_FLAGS="${{ inputs.PY_TEST_FLAGS }}"

--- a/.github/workflows/py-test.yaml
+++ b/.github/workflows/py-test.yaml
@@ -1,0 +1,73 @@
+name: py-test
+on:
+  workflow_call:
+    inputs:
+      PRIMUS_REF:
+        description: 'The primus ref to checkout.'
+        required: true
+        default: 'main'
+        type: string
+      PYTHON_VERSION:
+        description: 'The python version to use.'
+        required: false
+        default: '3.12'
+        type: string
+      PY_SRC:
+        description: 'The directory path containing the py source code.'
+        required: true
+        type: string
+      PY_PKG_MANAGER:
+        description: 'The python package manager to use.'
+        required: false
+        default: 'uv'
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
+jobs:
+  py:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: python-install
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.PYTHON_VERSION }}
+      - name: uv-install
+        if: ${{ inputs.PY_PKG_MANAGER == 'uv' }}
+        uses: astral-sh/setup-uv@v6
+      - name: info
+        run: |
+          $MAKE info
+      - name: py-test
+        run: |
+          $MAKE py-test SRC="$(pwd)/${{ inputs.PY_SRC }}"
+        env:
+          PY_PKG_MANAGER: ${{ inputs.PY_PKG_MANAGER }}

--- a/.github/workflows/py-type-check.yaml
+++ b/.github/workflows/py-type-check.yaml
@@ -1,0 +1,73 @@
+name: py-type-check
+on:
+  workflow_call:
+    inputs:
+      PRIMUS_REF:
+        description: 'The primus ref to checkout.'
+        required: true
+        default: 'main'
+        type: string
+      PYTHON_VERSION:
+        description: 'The python version to use.'
+        required: false
+        default: '3.12'
+        type: string
+      PY_SRC:
+        description: 'The directory path containing the py source code.'
+        required: true
+        type: string
+      PY_PKG_MANAGER:
+        description: 'The python package manager to use.'
+        required: false
+        default: 'uv'
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
+jobs:
+  py:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: python-install
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ inputs.PYTHON_VERSION }}
+      - name: uv-install
+        if: ${{ inputs.PY_PKG_MANAGER == 'uv' }}
+        uses: astral-sh/setup-uv@v6
+      - name: info
+        run: |
+          $MAKE info
+      - name: py-type-check
+        run: |
+          $MAKE py-type-check SRC="$(pwd)/${{ inputs.PY_SRC }}"
+        env:
+          PY_PKG_MANAGER: ${{ inputs.PY_PKG_MANAGER }}

--- a/.github/workflows/py-type-check.yaml
+++ b/.github/workflows/py-type-check.yaml
@@ -68,6 +68,4 @@ jobs:
           $MAKE info
       - name: py-type-check
         run: |
-          $MAKE py-type-check SRC="$(pwd)/${{ inputs.PY_SRC }}"
-        env:
-          PY_PKG_MANAGER: ${{ inputs.PY_PKG_MANAGER }}
+          $MAKE py-type-check SRC="$(pwd)/${{ inputs.PY_SRC }}" PY_PKG_MANAGER="${{ inputs.PY_PKG_MANAGER }}"


### PR DESCRIPTION
## Summary
- Adds reusable workflows for the Python toolchain, mirroring the existing `js-*` and `go-*` patterns: `py-build`, `py-fmt`, `py-lint`, `py-type-check`, `py-test`.
- Each installs Python via `actions/setup-python@v5` and conditionally installs `uv` via `astral-sh/setup-uv@v6` when `PY_PKG_MANAGER=uv` (the default).
- Workflows shell out to the corresponding `$MAKE py-*` targets defined in `signoz/primus`'s `src/make/cmd/py.mk`.