### PR TITLE
fix(py-build): hydrate submodules in self-checkout

### DIFF
--- a/.github/workflows/py-build.yaml
+++ b/.github/workflows/py-build.yaml
@@ -66,6 +66,8 @@ jobs:
     steps:
       - name: self-checkout
         uses: actions/checkout@v4
+        with:
+          submodules: recursive
       - id: token
         name: github-token-gen
         uses: actions/create-github-app-token@v1


### PR DESCRIPTION
## Summary
- `actions/checkout@v4` defaults to `submodules: false`, so the `self-checkout` step in `py-build.yaml` clones the consumer repo without its submodules.
- For repos that use submodules (e.g. [`signoz-ai-assistant`](https://github.com/SigNoz/signoz-ai-assistant) vendoring `agent-skills-src/`), the `docker-build` step then runs `COPY agent-skills-src/...` against an empty gitlink directory, producing a deployed image with missing files.
- Concrete production symptom on `signoz-ai-assistant`: every execution failed with `[Errno 2] No such file or directory: '/app/.claude/skills'` because the skills submodule was never hydrated during the image build (see [signoz-ai-assistant#151](https://github.com/SigNoz/signoz-ai-assistant/pull/151) for the consumer-side debugging).
- Fix: add `submodules: recursive` to the `self-checkout` step. No-op for repos without submodules; correct hydration for those that have them.
- Scoped this PR to `py-build.yaml` only since that's the workflow with the active production gap. The same one-line addition is likely valuable for `py-test`, `py-lint`, `py-fmt`, `py-type-check` (and the `go-*` / `js-*` build workflows), but those can be follow-ups once this lands.

## Test plan
- [ ] Re-run `signoz-ai-assistant`'s build workflow against `primus.workflows@<this-branch>` and confirm `agent-skills-src/plugins/signoz/skills/` is populated at `docker-build` time.
- [ ] Verify the resulting image has `/app/.claude/skills/` populated and a smoke execution succeeds.
- [ ] Spot-check a non-submodule consumer to confirm `submodules: recursive` is a no-op for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)