### PR TITLE
feat(kyaml): add kyaml-fmt workflow

### DIFF
--- a/.github/workflows/kyaml-fmt.yaml
+++ b/.github/workflows/kyaml-fmt.yaml
@@ -1,0 +1,55 @@
+name: kyaml-fmt
+on:
+  workflow_call:
+    inputs:
+      PRIMUS_REF:
+        description: 'The primus ref to checkout.'
+        required: true
+        default: 'main'
+        type: string
+      KYAML_SRC:
+        description: 'The directory path containing the yaml files to format. If not provided, defaults to the root of the repository.'
+        required: false
+        default: '.'
+        type: string
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  PRIMUS_HOME: .primus
+  MAKE: make --no-print-directory --makefile=.primus/src/make/main.mk
+
+jobs:
+  kyaml:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: self-checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      - id: token
+        name: github-token-gen
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.PRIMUS_APP_ID }}
+          private-key: ${{ secrets.PRIMUS_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: primus-checkout
+        uses: actions/checkout@v4
+        with:
+          repository: signoz/primus
+          ref: ${{ inputs.PRIMUS_REF }}
+          path: .primus
+          token: ${{ steps.token.outputs.token }}
+      - name: info
+        run: |
+          $MAKE info
+      - name: kyaml-fmt
+        run: |
+          $MAKE kyaml-fmt KYAML_SRC="$(pwd)/${{ inputs.KYAML_SRC }}"


### PR DESCRIPTION
## Summary
- Adds a reusable `kyaml-fmt` workflow that runs the `kyaml fmt` make target from `primus/src/make/cmd/kyaml.mk`.
- Exposes an optional `KYAML_SRC` input (defaults to repo root), wired through to make as `KYAML_SRC=\$(pwd)/<input>` — same pattern as `JS_SRC` / `PY_SRC` in the other formatter workflows.
- No language runtime install needed: the `kyaml` binary is already committed under `primus/bin/go/kyaml/<os>-<arch>/` and resolved via `PRIMUS_BIN` in the makefile.
